### PR TITLE
NO-JIRA Small loader fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,12 +27,9 @@ const cssModuleToInterface = (cssModuleKeys) => {
     .map(key => `  ${key}: string`)
     .join('\n');
 
-  console.log('Module Start')
-  console.log(cssModuleKeys)
-  console.log(interfaceFields)
-  console.log('----------------------')
-
-  return `interface CssExports {\n${interfaceFields}\n}`;
+  return cssModuleKeys && cssModuleKeys.length
+    ? `interface CssExports {\n${interfaceFields}\n}`
+    : 'interface CssExports {}' ;
 };
 
 const filenameToTypingsFilename = filename => {

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ const cssModuleToInterface = (cssModuleKeys) => {
     .map(key => `  ${key}: string`)
     .join('\n');
 
+  console.log(interfaceFields)
+
   return `interface CssExports {\n${interfaceFields}\n}`;
 };
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,10 @@ const cssModuleToInterface = (cssModuleKeys) => {
     .map(key => `  ${key}: string`)
     .join('\n');
 
+  console.log('Module Start')
+  console.log(cssModuleKeys)
   console.log(interfaceFields)
+  console.log('----------------------')
 
   return `interface CssExports {\n${interfaceFields}\n}`;
 };


### PR DESCRIPTION
This will prevent an empty newline from being added when there are no CSS rules to generate. This is currently happening for base.less all the time and devs have to keep reverting the newline change to this file.